### PR TITLE
DM-23757: Deploy xml 4.7 at the summit.

### DIFF
--- a/AT_CSC/ataos_setup.sh
+++ b/AT_CSC/ataos_setup.sh
@@ -5,4 +5,4 @@ source ~/miniconda3/bin/activate
 source $OSPL_HOME/release.com
 source /home/saluser/.bashrc
 
-run_atdometrajectory.py
+ataos_csc.py

--- a/AT_CSC/atdome_setup.sh
+++ b/AT_CSC/atdome_setup.sh
@@ -1,22 +1,8 @@
 #!/usr/bin/env bash
 
-# Source this file when starting the container to set it up
 
-echo "#"
-echo "# Loading LSST Stack"
-. /opt/lsst/software/stack/loadLSST.bash
-setup lsst_distrib
-echo "#"
-echo "# Loading sal environment"
-. /home/saluser/repos/ts_sal/setup.env
-echo "#"
-echo "# Setting ATDome Simulator"
-
-cd ~/repos/ts_config_attcs/
-git fetch --all
-git checkout "tags/v0.2.0" -b "v0.2.0"
-cd
-
-setup ts_ATDome -t current
+source ~/miniconda3/bin/activate
+source $OSPL_HOME/release.com
+source /home/saluser/.bashrc
 
 run_atdome.py

--- a/AT_CSC/athexapod_setup.sh
+++ b/AT_CSC/athexapod_setup.sh
@@ -5,4 +5,4 @@ source ~/miniconda3/bin/activate
 source $OSPL_HOME/release.com
 source /home/saluser/.bashrc
 
-run_atdometrajectory.py
+runATHexapodCSC.py

--- a/AT_CSC/atspec_setup.sh
+++ b/AT_CSC/atspec_setup.sh
@@ -5,4 +5,4 @@ source ~/miniconda3/bin/activate
 source $OSPL_HOME/release.com
 source /home/saluser/.bashrc
 
-run_atdometrajectory.py
+atspec_csc.py

--- a/AT_CSC/docker-compose.yaml
+++ b/AT_CSC/docker-compose.yaml
@@ -3,10 +3,10 @@ version: '3.6'
 services:
 
   atptg:
-    image: ts-dockerhub.lsst.org/ptkernel:v1.1.0_rc3_b22
+    image: ts-dockerhub.lsst.org/ptkernel:v1.1.0_rc4_b42
     container_name: atptg
     environment:
-      - LSST_DDS_DOMAIN=${LSST_DDS_DOMAIN}
+      - LSST_DDS_DOMAIN=lsatmcs
       - TELESCOPE=AuxTel
     networks:
       control-network:
@@ -18,10 +18,10 @@ services:
             max-size: "10m"
 
   atdome:
-    image: lsstts/develop-env:b36
+    image: lsstts/atdome:v1.1_salobj_v5.4.0_idl_v1.1.2_xml_v4.7.0
     container_name: atdome
     environment:
-      - LSST_DDS_DOMAIN=${LSST_DDS_DOMAIN}
+      - LSST_DDS_DOMAIN=lsatmcs
     volumes:
       - ./atdome_setup.sh:/home/saluser/.setup.sh
     networks:
@@ -34,10 +34,10 @@ services:
             max-size: "10m"
 
   atdometrajectory:
-    image: lsstts/develop-env:b22
+    image: lsstts/atdometrajectory:v1.2_salobj_v5.4.0_idl_v1.1.2_xml_v4.7.0
     container_name: atdometrajectory
     environment:
-      - LSST_DDS_DOMAIN=${LSST_DDS_DOMAIN}
+      - LSST_DDS_DOMAIN=lsatmcs
     volumes:
       - ./atdometrajectory_setup.sh:/home/saluser/.setup.sh
     networks:
@@ -49,10 +49,12 @@ services:
             max-file: "5"
             max-size: "10m"
   athexapod:
-    image: lsstts/ts_athexapod:v0.3.0_b31
+    image: lsstts/athexapod:v0.4_salobj_v5.4.0_idl_v1.1.2_xml_v4.7.0
     container_name: athexapod
     environment:
-      - LSST_DDS_DOMAIN=${LSST_DDS_DOMAIN}
+      - LSST_DDS_DOMAIN=lsatmcs
+    volumes:
+      - ./athexapod_setup.sh:/home/saluser/.setup.sh
     networks:
       control-network:
         ipv4_address: "139.229.170.234"
@@ -62,10 +64,12 @@ services:
             max-file: "5"
             max-size: "10m"
   ataos:
-    image: lsstts/ataos:v1.5.0
+    image: lsstts/ataos:v1.5_salobj_v5.4.0_idl_v1.1.2_xml_v4.7.0
     container_name: ataos
     environment:
-      - LSST_DDS_DOMAIN=${LSST_DDS_DOMAIN}
+      - LSST_DDS_DOMAIN=lsatmcs
+    volumes:
+      - ./ataos_setup.sh:/home/saluser/.setup.sh
     networks:
       control-network:
         ipv4_address: "139.229.170.235"
@@ -76,10 +80,10 @@ services:
             max-size: "10m"
 
   atheaderservice:
-    image: lsstts/at_headerservice:v1.4.0_salobj_v5.0.0_xml_v4.6.0
+    image: lsstts/at_headerservice:v1.4.0_salobj_v5.4.0_idl_v1.1.2_xml_v4.7.0
     container_name: atheaderservice
     environment:
-      - LSST_DDS_DOMAIN=${LSST_DDS_DOMAIN}
+      - LSST_DDS_DOMAIN=lsatmcs
     volumes:
       - ./aths_setup.sh:/home/saluser/.setup.sh
       - /home/saluser/ATHS_data/www/:/home/saluser/www/
@@ -93,10 +97,12 @@ services:
             max-size: "10m"
 
   atspectrograph:
-    image: lsstts/atspectrograph:v0.5.0_b32
+    image: lsstts/atspec:v0.5_salobj_v5.4.0_idl_v1.1.2_xml_v4.7.0
     container_name: atspectrograph
     environment:
-      - LSST_DDS_DOMAIN=${LSST_DDS_DOMAIN}
+      - LSST_DDS_DOMAIN=lsatmcs
+    volumes:
+      - ./atspec_setup.sh:/home/saluser/.setup.sh
     networks:
       control-network:
         ipv4_address: "139.229.170.230"

--- a/EFD/docker-compose.yaml
+++ b/EFD/docker-compose.yaml
@@ -3,16 +3,16 @@ version: "3.4"
 services:
 
   salkafka_producer_01:
-    image: lsstts/salkafka:v1.1.0_xml_v4.6.0
+    image: lsstts/salkafka:v1.1.1_salobj_v5.4.0_idl_v1.1.2_xml_v4.7.0
     container_name: salkafka_producer_01
     environment:
-      - LSST_DDS_DOMAIN=${LSST_DDS_DOMAIN}
+      - LSST_DDS_DOMAIN=lsatmcs
       - BROKER_IP=kafka-0-summit-efd.lsst.codes
       - BROKER_PORT=31090
       - REGISTRY_ADDR=https://schema-registry-summit-efd.lsst.codes
       - REPLICATION=3
-      - LOG_LEVEL=10
-      - CSC_LIST=ATPtg ATMCS ATHexapod ATDomeTrajectory ATPneumatics
+      - LOG_LEVEL=20
+      - CSC_LIST=ATPtg ATMCS ATHexapod ATDomeTrajectory ATPneumatics ATAOS
     stdin_open: true
     tty: true
     networks:
@@ -25,15 +25,15 @@ services:
             max-size: "10m"
 
   salkafka_producer_02:
-    image: lsstts/salkafka:v1.1.0_xml_v4.6.0
+    image: lsstts/salkafka:v1.1.1_salobj_v5.4.0_idl_v1.1.2_xml_v4.7.0
     container_name: salkafka_producer_02
     environment:
-      - LSST_DDS_DOMAIN=${LSST_DDS_DOMAIN}
+      - LSST_DDS_DOMAIN=lsatmcs
       - BROKER_IP=kafka-0-summit-efd.lsst.codes
       - BROKER_PORT=31090
       - REGISTRY_ADDR=https://schema-registry-summit-efd.lsst.codes
       - REPLICATION=3
-      - LOG_LEVEL=10
+      - LOG_LEVEL=20
       - CSC_LIST=ATHeaderService ATArchiver ATSpectrograph ScriptQueue Script ATDome DIMM Environment GenericCamera Watcher
     stdin_open: true
     tty: true
@@ -47,15 +47,15 @@ services:
             max-size: "10m"
 
   salkafka_producer_03:
-    image: lsstts/salkafka:v1.1.0_xml_v4.6.0
+    image: lsstts/salkafka:v1.1.1_salobj_v5.4.0_idl_v1.1.2_xml_v4.7.0
     container_name: salkafka_producer_03
     environment:
-      - LSST_DDS_DOMAIN=${LSST_DDS_DOMAIN}
+      - LSST_DDS_DOMAIN=lsatmcs
       - BROKER_IP=kafka-0-summit-efd.lsst.codes
       - BROKER_PORT=31090
       - REGISTRY_ADDR=https://schema-registry-summit-efd.lsst.codes
       - REPLICATION=3
-      - LOG_LEVEL=10
+      - LOG_LEVEL=20
       - CSC_LIST=ATCamera DSM
     stdin_open: true
     tty: true
@@ -69,16 +69,16 @@ services:
             max-size: "10m"
 
   salkafka_producer_04:
-    image: lsstts/salkafka:v1.1.0_DM-22700
+    image: lsstts/salkafka:v1.1.1_salobj_v5.4.0_idl_v1.1.2_xml_v4.7.0
     container_name: salkafka_producer_04
     environment:
-      - LSST_DDS_DOMAIN=${LSST_DDS_DOMAIN}
+      - LSST_DDS_DOMAIN=lsatmcs
       - BROKER_IP=kafka-0-summit-efd.lsst.codes
       - BROKER_PORT=31090
       - REGISTRY_ADDR=https://schema-registry-summit-efd.lsst.codes
       - REPLICATION=3
       - LOG_LEVEL=10
-      - CSC_LIST=ATAOS
+      - CSC_LIST=Scheduler
     stdin_open: true
     tty: true
     networks:
@@ -122,7 +122,7 @@ services:
       - REGISTRY_ADDR=https://schema-registry-summit-efd.lsst.codes
       - REPLICATION=3
       - LOG_LEVEL=10
-      - CSC_LIST=MTM2
+      - CSC_LIST=MTM2 Hexapod Rotator
     stdin_open: true
     tty: true
     networks:

--- a/MT_CSC/docker-compose.yml
+++ b/MT_CSC/docker-compose.yml
@@ -1,0 +1,21 @@
+version: "3.4"
+
+services:
+
+  mt-hexapod-m2:
+    image: lsstts/hexapod:v0.4.0_b42
+    container_name: mt-hexapod-m2
+    environment:
+      - LSST_DDS_DOMAIN=m2
+      - HEXAPOD_ID=2
+    tty: true
+    networks:
+      control-network:
+        ipv4_address: "139.229.170.10"
+
+networks:
+  default:
+    external:
+      name: control-network
+  control-network:
+    external: true

--- a/OCS/docker-compose.yaml
+++ b/OCS/docker-compose.yaml
@@ -44,7 +44,7 @@ services:
     entrypoint: ["/home/lsst/.setup.sh"]
 
   watcher:
-    image: lsstts/watcher:v1.0.1
+    image: lsstts/watcher:v1.0.2_rc1
     container_name: watcher
     environment:
       - LSST_DDS_DOMAIN=${LSST_DDS_DOMAIN}
@@ -53,7 +53,7 @@ services:
         ipv4_address: "139.229.170.221"
 
   queue:
-    image: lsstts/develop-env:b22
+    image: lsstts/develop-env:b45
     container_name: queue
     environment:
       - LSST_DDS_DOMAIN=${LSST_DDS_DOMAIN}
@@ -65,6 +65,19 @@ services:
       control-network:
         ipv4_address: "139.229.170.229"
 
+  at_scheduler:
+    image: lsstts/scheduler:DM-23757_b45
+    container_name: at_scheduler
+    environment:
+      - LSST_DDS_DOMAIN=${LSST_DDS_DOMAIN}
+      - INDEX=2
+    volumes:
+      - /net/scratch/at-scheduler:/home/saluser/data
+    stdin_open: true
+    tty: true
+    networks:
+      control-network:
+        ipv4_address: "139.229.170.237"
 
 networks:
   default:

--- a/users_jupyter_servers/diag13_notebook_config.py
+++ b/users_jupyter_servers/diag13_notebook_config.py
@@ -1,0 +1,2 @@
+
+c.NotebookApp.token = '90ee5fc573916e15755dfc013f8d195240e1f59e9f2e3cfe'

--- a/users_jupyter_servers/diag13_setup.sh
+++ b/users_jupyter_servers/diag13_setup.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# Source this file when starting the container to set it up
+
+. ~/.bash_profile
+echo "#"
+echo "# Loading sal environment"
+. repos/ts_sal/setup.env
+echo "#"
+echo "# Loading LSST Stack"
+. /opt/lsst/software/stack/loadLSST.bash
+setup lsst_distrib
+echo "#"
+echo "# Setting up sal, salobj and scriptqueue"
+
+setup ts_xml -t current
+setup ts_sal -t current
+setup ts_salobj -t current
+setup ts_scriptqueue -t current
+
+echo "#"
+echo "# Starting jupyter lab server"
+
+jupyter lab --ip 139.229.170.213 --port 8885 --no-browser

--- a/users_jupyter_servers/diag14_notebook_config.py
+++ b/users_jupyter_servers/diag14_notebook_config.py
@@ -1,0 +1,2 @@
+
+c.NotebookApp.token = '4683b245f4231304ff1c0c4595475a55a1d2efd55dea5529'

--- a/users_jupyter_servers/diag14_setup.sh
+++ b/users_jupyter_servers/diag14_setup.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# Source this file when starting the container to set it up
+
+. ~/.bash_profile
+echo "#"
+echo "# Loading sal environment"
+. repos/ts_sal/setup.env
+echo "#"
+echo "# Loading LSST Stack"
+. /opt/lsst/software/stack/loadLSST.bash
+setup lsst_distrib
+echo "#"
+echo "# Setting up sal, salobj and scriptqueue"
+
+setup ts_xml -t current
+setup ts_sal -t current
+setup ts_salobj -t current
+setup ts_scriptqueue -t current
+
+echo "#"
+echo "# Starting jupyter lab server"
+
+jupyter lab --ip 139.229.170.214 --port 8885 --no-browser

--- a/users_jupyter_servers/docker-compose.yml
+++ b/users_jupyter_servers/docker-compose.yml
@@ -4,10 +4,10 @@ services:
 
   # user: Patrick
   diag01:
-    image: lsstts/develop-env:b32
+    image: lsstts/develop-env:b45
     container_name: diag01
     environment:
-      - LSST_DDS_DOMAIN=$LSST_DDS_DOMAIN
+      - LSST_DDS_DOMAIN=lsatmcs
     volumes:
       - $USERS_DATA/develop_diag01:/home/saluser/develop
       - $USERS_DATA/shared/:/home/saluser/shared/
@@ -15,9 +15,9 @@ services:
       - ./diag01_setup.sh:/home/saluser/.setup.sh
       - /mnt/dmcs/data/:/mnt/dmcs/data/
       - $USERS_DATA/repo:/mnt/dmcs/oods_butler_repo/repo/
-      - /mnt/dmcs/oods_butler_repo/repo/_mapper:/mnt/dmcs/oods_butler_repo/repo/_mapper
-      - /mnt/dmcs/oods_butler_repo/repo/raw:/mnt/dmcs/oods_butler_repo/repo/raw
-      - /mnt/dmcs/oods_butler_repo/repo/registry.sqlite3:/mnt/dmcs/oods_butler_repo/repo/registry.sqlite3
+      - /mnt/dmcs/oods_butler_repo/_mapper:/mnt/dmcs/oods_butler_repo/repo/_mapper
+      - /mnt/dmcs/oods_butler_repo/raw:/mnt/dmcs/oods_butler_repo/repo/raw
+      - /mnt/dmcs/oods_butler_repo/registry.sqlite3:/mnt/dmcs/oods_butler_repo/repo/registry.sqlite3
     stdin_open: true
     tty: true
     networks:
@@ -31,10 +31,10 @@ services:
             max-size: "10m"
   # user: Eric
   diag02:
-    image: lsstts/develop-env:b32
+    image: lsstts/develop-env:b45
     container_name: diag02
     environment:
-      - LSST_DDS_DOMAIN=$LSST_DDS_DOMAIN
+      - LSST_DDS_DOMAIN=lsatmcs
     volumes:
       - $USERS_DATA/develop_diag02:/home/saluser/develop
       - $USERS_DATA/shared/:/home/saluser/shared/
@@ -43,9 +43,9 @@ services:
       - /mnt/data/:/mnt/data
       - /mnt/dmcs/data/:/mnt/dmcs/data/
       - $USERS_DATA/repo:/mnt/dmcs/oods_butler_repo/repo/
-      - /mnt/dmcs/oods_butler_repo/repo/_mapper:/mnt/dmcs/oods_butler_repo/repo/_mapper
-      - /mnt/dmcs/oods_butler_repo/repo/raw:/mnt/dmcs/oods_butler_repo/repo/raw
-      - /mnt/dmcs/oods_butler_repo/repo/registry.sqlite3:/mnt/dmcs/oods_butler_repo/repo/registry.sqlite3
+      - /mnt/dmcs/oods_butler_repo/_mapper:/mnt/dmcs/oods_butler_repo/repo/_mapper
+      - /mnt/dmcs/oods_butler_repo/raw:/mnt/dmcs/oods_butler_repo/repo/raw
+      - /mnt/dmcs/oods_butler_repo/registry.sqlite3:/mnt/dmcs/oods_butler_repo/repo/registry.sqlite3
     stdin_open: true
     tty: true
     networks:
@@ -58,10 +58,10 @@ services:
             max-size: "10m"
   # user: Tiago
   diag03:
-    image: lsstts/develop-env:b32
+    image: lsstts/develop-env:b45
     container_name: diag03
     environment:
-      - LSST_DDS_DOMAIN=$LSST_DDS_DOMAIN
+      - LSST_DDS_DOMAIN=lsatmcs
     volumes:
       - $USERS_DATA/develop_diag03:/home/saluser/develop
       - $USERS_DATA/shared/:/home/saluser/shared/
@@ -70,9 +70,9 @@ services:
       - /mnt/data/:/mnt/data
       - /mnt/dmcs/data/:/mnt/dmcs/data/
       - $USERS_DATA/repo:/mnt/dmcs/oods_butler_repo/repo/
-      - /mnt/dmcs/oods_butler_repo/repo/_mapper:/mnt/dmcs/oods_butler_repo/repo/_mapper
-      - /mnt/dmcs/oods_butler_repo/repo/raw:/mnt/dmcs/oods_butler_repo/repo/raw
-      - /mnt/dmcs/oods_butler_repo/repo/registry.sqlite3:/mnt/dmcs/oods_butler_repo/repo/registry.sqlite3
+      - /mnt/dmcs/oods_butler_repo/_mapper:/mnt/dmcs/oods_butler_repo/repo/_mapper
+      - /mnt/dmcs/oods_butler_repo/raw:/mnt/dmcs/oods_butler_repo/repo/raw
+      - /mnt/dmcs/oods_butler_repo/registry.sqlite3:/mnt/dmcs/oods_butler_repo/repo/registry.sqlite3
     stdin_open: true
     tty: true
     networks:
@@ -85,10 +85,10 @@ services:
             max-size: "10m"
   # user: Brian
   diag04:
-    image: lsstts/develop-env:b32
+    image: lsstts/develop-env:b45
     container_name: diag04
     environment:
-      - LSST_DDS_DOMAIN=$LSST_DDS_DOMAIN
+      - LSST_DDS_DOMAIN=lsatmcs
     volumes:
       - $USERS_DATA/develop_diag04:/home/saluser/develop
       - $USERS_DATA/shared/:/home/saluser/shared/
@@ -97,9 +97,9 @@ services:
       - /mnt/data/:/mnt/data
       - /mnt/dmcs/data/:/mnt/dmcs/data/
       - $USERS_DATA/repo:/mnt/dmcs/oods_butler_repo/repo/
-      - /mnt/dmcs/oods_butler_repo/repo/_mapper:/mnt/dmcs/oods_butler_repo/repo/_mapper
-      - /mnt/dmcs/oods_butler_repo/repo/raw:/mnt/dmcs/oods_butler_repo/repo/raw
-      - /mnt/dmcs/oods_butler_repo/repo/registry.sqlite3:/mnt/dmcs/oods_butler_repo/repo/registry.sqlite3
+      - /mnt/dmcs/oods_butler_repo/_mapper:/mnt/dmcs/oods_butler_repo/repo/_mapper
+      - /mnt/dmcs/oods_butler_repo/raw:/mnt/dmcs/oods_butler_repo/repo/raw
+      - /mnt/dmcs/oods_butler_repo/registry.sqlite3:/mnt/dmcs/oods_butler_repo/repo/registry.sqlite3
     stdin_open: true
     tty: true
     networks:
@@ -112,10 +112,10 @@ services:
             max-size: "10m"
   # user: Robert
   diag05:
-    image: lsstts/develop-env:b32
+    image: lsstts/develop-env:b45
     container_name: diag05
     environment:
-      - LSST_DDS_DOMAIN=$LSST_DDS_DOMAIN
+      - LSST_DDS_DOMAIN=lsatmcs
     volumes:
       - $USERS_DATA/develop_diag05:/home/saluser/develop
       - $USERS_DATA/shared/:/home/saluser/shared/
@@ -124,9 +124,9 @@ services:
       - /mnt/data/:/mnt/data
       - /mnt/dmcs/data/:/mnt/dmcs/data/
       - $USERS_DATA/repo:/mnt/dmcs/oods_butler_repo/repo/
-      - /mnt/dmcs/oods_butler_repo/repo/_mapper:/mnt/dmcs/oods_butler_repo/repo/_mapper
-      - /mnt/dmcs/oods_butler_repo/repo/raw:/mnt/dmcs/oods_butler_repo/repo/raw
-      - /mnt/dmcs/oods_butler_repo/repo/registry.sqlite3:/mnt/dmcs/oods_butler_repo/repo/registry.sqlite3
+      - /mnt/dmcs/oods_butler_repo/_mapper:/mnt/dmcs/oods_butler_repo/repo/_mapper
+      - /mnt/dmcs/oods_butler_repo/raw:/mnt/dmcs/oods_butler_repo/repo/raw
+      - /mnt/dmcs/oods_butler_repo/registry.sqlite3:/mnt/dmcs/oods_butler_repo/repo/registry.sqlite3
     stdin_open: true
     tty: true
     networks:
@@ -139,10 +139,10 @@ services:
             max-size: "10m"
   # user: Kevin Reil
   diag06:
-    image: lsstts/develop-env:b32
+    image: lsstts/develop-env:b45
     container_name: diag06
     environment:
-      - LSST_DDS_DOMAIN=$LSST_DDS_DOMAIN
+      - LSST_DDS_DOMAIN=lsatmcs
     volumes:
       - $USERS_DATA/develop_diag06:/home/saluser/develop
       - $USERS_DATA/shared/:/home/saluser/shared/
@@ -151,9 +151,9 @@ services:
       - /mnt/data/:/mnt/data
       - /mnt/dmcs/data/:/mnt/dmcs/data/
       - $USERS_DATA/repo:/mnt/dmcs/oods_butler_repo/repo/
-      - /mnt/dmcs/oods_butler_repo/repo/_mapper:/mnt/dmcs/oods_butler_repo/repo/_mapper
-      - /mnt/dmcs/oods_butler_repo/repo/raw:/mnt/dmcs/oods_butler_repo/repo/raw
-      - /mnt/dmcs/oods_butler_repo/repo/registry.sqlite3:/mnt/dmcs/oods_butler_repo/repo/registry.sqlite3
+      - /mnt/dmcs/oods_butler_repo/_mapper:/mnt/dmcs/oods_butler_repo/repo/_mapper
+      - /mnt/dmcs/oods_butler_repo/raw:/mnt/dmcs/oods_butler_repo/repo/raw
+      - /mnt/dmcs/oods_butler_repo/registry.sqlite3:/mnt/dmcs/oods_butler_repo/repo/registry.sqlite3
     stdin_open: true
     tty: true
     networks:
@@ -167,10 +167,10 @@ services:
 
   # user: cslange
   diag07:
-    image: lsstts/develop-env:b32
+    image: lsstts/develop-env:b45
     container_name: diag07
     environment:
-      - LSST_DDS_DOMAIN=$LSST_DDS_DOMAIN
+      - LSST_DDS_DOMAIN=lsatmcs
     volumes:
       - $USERS_DATA/develop_diag07:/home/saluser/develop
       - $USERS_DATA/shared/:/home/saluser/shared/
@@ -179,9 +179,9 @@ services:
       - /mnt/data/:/mnt/data
       - /mnt/dmcs/data/:/mnt/dmcs/data/
       - $USERS_DATA/repo:/mnt/dmcs/oods_butler_repo/repo/
-      - /mnt/dmcs/oods_butler_repo/repo/_mapper:/mnt/dmcs/oods_butler_repo/repo/_mapper
-      - /mnt/dmcs/oods_butler_repo/repo/raw:/mnt/dmcs/oods_butler_repo/repo/raw
-      - /mnt/dmcs/oods_butler_repo/repo/registry.sqlite3:/mnt/dmcs/oods_butler_repo/repo/registry.sqlite3
+      - /mnt/dmcs/oods_butler_repo/_mapper:/mnt/dmcs/oods_butler_repo/repo/_mapper
+      - /mnt/dmcs/oods_butler_repo/raw:/mnt/dmcs/oods_butler_repo/repo/raw
+      - /mnt/dmcs/oods_butler_repo/registry.sqlite3:/mnt/dmcs/oods_butler_repo/repo/registry.sqlite3
     stdin_open: true
     tty: true
     networks:
@@ -195,10 +195,10 @@ services:
 
   # user: merlin
   diag08:
-    image: lsstts/develop-env:b32
+    image: lsstts/develop-env:b45
     container_name: diag08
     environment:
-      - LSST_DDS_DOMAIN=$LSST_DDS_DOMAIN
+      - LSST_DDS_DOMAIN=lsatmcs
     volumes:
       - $USERS_DATA/develop_diag08:/home/saluser/develop
       - $USERS_DATA/shared/:/home/saluser/shared/
@@ -207,9 +207,9 @@ services:
       - /mnt/data/:/mnt/data
       - /mnt/dmcs/data/:/mnt/dmcs/data/
       - $USERS_DATA/repo:/mnt/dmcs/oods_butler_repo/repo/
-      - /mnt/dmcs/oods_butler_repo/repo/_mapper:/mnt/dmcs/oods_butler_repo/repo/_mapper
-      - /mnt/dmcs/oods_butler_repo/repo/raw:/mnt/dmcs/oods_butler_repo/repo/raw
-      - /mnt/dmcs/oods_butler_repo/repo/registry.sqlite3:/mnt/dmcs/oods_butler_repo/repo/registry.sqlite3
+      - /mnt/dmcs/oods_butler_repo/_mapper:/mnt/dmcs/oods_butler_repo/repo/_mapper
+      - /mnt/dmcs/oods_butler_repo/raw:/mnt/dmcs/oods_butler_repo/repo/raw
+      - /mnt/dmcs/oods_butler_repo/registry.sqlite3:/mnt/dmcs/oods_butler_repo/repo/registry.sqlite3
     stdin_open: true
     tty: true
     networks:
@@ -223,10 +223,10 @@ services:
 
   # user: Michael
   diag09:
-    image: lsstts/develop-env:b32
+    image: lsstts/develop-env:b45
     container_name: diag09
     environment:
-      - LSST_DDS_DOMAIN=$LSST_DDS_DOMAIN
+      - LSST_DDS_DOMAIN=lsatmcs
     volumes:
       - $USERS_DATA/develop_diag09:/home/saluser/develop
       - $USERS_DATA/shared/:/home/saluser/shared/
@@ -235,9 +235,9 @@ services:
       - /mnt/data/:/mnt/data
       - /mnt/dmcs/data/:/mnt/dmcs/data/
       - $USERS_DATA/repo:/mnt/dmcs/oods_butler_repo/repo/
-      - /mnt/dmcs/oods_butler_repo/repo/_mapper:/mnt/dmcs/oods_butler_repo/repo/_mapper
-      - /mnt/dmcs/oods_butler_repo/repo/raw:/mnt/dmcs/oods_butler_repo/repo/raw
-      - /mnt/dmcs/oods_butler_repo/repo/registry.sqlite3:/mnt/dmcs/oods_butler_repo/repo/registry.sqlite3
+      - /mnt/dmcs/oods_butler_repo/_mapper:/mnt/dmcs/oods_butler_repo/repo/_mapper
+      - /mnt/dmcs/oods_butler_repo/raw:/mnt/dmcs/oods_butler_repo/repo/raw
+      - /mnt/dmcs/oods_butler_repo/registry.sqlite3:/mnt/dmcs/oods_butler_repo/repo/registry.sqlite3
     stdin_open: true
     tty: true
     networks:
@@ -267,10 +267,10 @@ services:
 
   # user: Chris Stubbs
   diag11:
-    image: lsstts/develop-env:b32
+    image: lsstts/develop-env:b45
     container_name: diag11
     environment:
-      - LSST_DDS_DOMAIN=$LSST_DDS_DOMAIN
+      - LSST_DDS_DOMAIN=lsatmcs
     volumes:
       - $USERS_DATA/develop_diag11:/home/saluser/develop
       - $USERS_DATA/shared/:/home/saluser/shared/
@@ -279,9 +279,9 @@ services:
       - /mnt/data/:/mnt/data
       - /mnt/dmcs/data/:/mnt/dmcs/data/
       - $USERS_DATA/repo:/mnt/dmcs/oods_butler_repo/repo/
-      - /mnt/dmcs/oods_butler_repo/repo/_mapper:/mnt/dmcs/oods_butler_repo/repo/_mapper
-      - /mnt/dmcs/oods_butler_repo/repo/raw:/mnt/dmcs/oods_butler_repo/repo/raw
-      - /mnt/dmcs/oods_butler_repo/repo/registry.sqlite3:/mnt/dmcs/oods_butler_repo/repo/registry.sqlite3
+      - /mnt/dmcs/oods_butler_repo/_mapper:/mnt/dmcs/oods_butler_repo/repo/_mapper
+      - /mnt/dmcs/oods_butler_repo/raw:/mnt/dmcs/oods_butler_repo/repo/raw
+      - /mnt/dmcs/oods_butler_repo/registry.sqlite3:/mnt/dmcs/oods_butler_repo/repo/registry.sqlite3
     stdin_open: true
     tty: true
     networks:
@@ -295,10 +295,10 @@ services:
 
   # user: SashaBrownsberger
   diag12:
-    image: lsstts/develop-env:b32
+    image: lsstts/develop-env:b45
     container_name: diag12
     environment:
-      - LSST_DDS_DOMAIN=$LSST_DDS_DOMAIN
+      - LSST_DDS_DOMAIN=lsatmcs
     volumes:
       - $USERS_DATA/develop_diag12:/home/saluser/develop
       - $USERS_DATA/shared/:/home/saluser/shared/
@@ -307,14 +307,70 @@ services:
       - /mnt/data/:/mnt/data
       - /mnt/dmcs/data/:/mnt/dmcs/data/
       - $USERS_DATA/repo:/mnt/dmcs/oods_butler_repo/repo/
-      - /mnt/dmcs/oods_butler_repo/repo/_mapper:/mnt/dmcs/oods_butler_repo/repo/_mapper
-      - /mnt/dmcs/oods_butler_repo/repo/raw:/mnt/dmcs/oods_butler_repo/repo/raw
-      - /mnt/dmcs/oods_butler_repo/repo/registry.sqlite3:/mnt/dmcs/oods_butler_repo/repo/registry.sqlite3
+      - /mnt/dmcs/oods_butler_repo/_mapper:/mnt/dmcs/oods_butler_repo/repo/_mapper
+      - /mnt/dmcs/oods_butler_repo/raw:/mnt/dmcs/oods_butler_repo/repo/raw
+      - /mnt/dmcs/oods_butler_repo/registry.sqlite3:/mnt/dmcs/oods_butler_repo/repo/registry.sqlite3
     stdin_open: true
     tty: true
     networks:
       control-network:
         ipv4_address: "139.229.170.212"
+    logging:
+        driver: "json-file"
+        options:
+            max-file: "5"
+            max-size: "10m"
+
+  # user: Andrew
+  diag13:
+    image: lsstts/develop-env:b45
+    container_name: diag13
+    environment:
+      - LSST_DDS_DOMAIN=m2
+    volumes:
+      - $USERS_DATA/develop_diag13:/home/saluser/develop
+      - $USERS_DATA/shared/:/home/saluser/shared/
+      - ./diag13_notebook_config.py:/home/saluser/.jupyter/jupyter_notebook_config.py
+      - ./diag13_setup.sh:/home/saluser/.setup.sh
+#      - /mnt/data/:/mnt/data
+#      - /mnt/dmcs/data/:/mnt/dmcs/data/
+#      - $USERS_DATA/repo:/mnt/dmcs/oods_butler_repo/repo/
+#      - /mnt/dmcs/oods_butler_repo/_mapper:/mnt/dmcs/oods_butler_repo/repo/_mapper
+#      - /mnt/dmcs/oods_butler_repo/raw:/mnt/dmcs/oods_butler_repo/repo/raw
+#      - /mnt/dmcs/oods_butler_repo/registry.sqlite3:/mnt/dmcs/oods_butler_repo/repo/registry.sqlite3
+    stdin_open: true
+    tty: true
+    networks:
+      control-network:
+        ipv4_address: "139.229.170.213"
+    logging:
+        driver: "json-file"
+        options:
+            max-file: "5"
+            max-size: "10m"
+
+  # user: TeWei
+  diag14:
+    image: lsstts/develop-env:b45
+    container_name: diag14
+    environment:
+      - LSST_DDS_DOMAIN=m2
+    volumes:
+      - $USERS_DATA/develop_diag14:/home/saluser/develop
+      - $USERS_DATA/shared/:/home/saluser/shared/
+      - ./diag14_notebook_config.py:/home/saluser/.jupyter/jupyter_notebook_config.py
+      - ./diag14_setup.sh:/home/saluser/.setup.sh
+#      - /mnt/data/:/mnt/data
+#      - /mnt/dmcs/data/:/mnt/dmcs/data/
+#      - $USERS_DATA/repo:/mnt/dmcs/oods_butler_repo/repo/
+#      - /mnt/dmcs/oods_butler_repo/_mapper:/mnt/dmcs/oods_butler_repo/repo/_mapper
+#      - /mnt/dmcs/oods_butler_repo/raw:/mnt/dmcs/oods_butler_repo/repo/raw
+#      - /mnt/dmcs/oods_butler_repo/registry.sqlite3:/mnt/dmcs/oods_butler_repo/repo/registry.sqlite3
+    stdin_open: true
+    tty: true
+    networks:
+      control-network:
+        ipv4_address: "139.229.170.214"
     logging:
         driver: "json-file"
         options:


### PR DESCRIPTION
Add producer for the scheduler.
Update scheduler deployment to not override the setup.sh file.
Add at scheduler.
Deploy watcher and AT Queue
Fix path to butler data.
Fix setup for TeWei's jupyter server
Add notebook server for TeWei.
Run MT M2 Hexapod in normal mode instead of simulation.
Fixes network name on hexapod.
Add M2 hexapod deployment.
Add notebook server for Andrew Heyer.
Update pointing component deployment.
Update kafka producers.
Update AT components to xml 4.7 using the deployment container.